### PR TITLE
Interrupt bug fixes

### DIFF
--- a/LIS3DH.class.nut
+++ b/LIS3DH.class.nut
@@ -1,5 +1,5 @@
 class LIS3DH {
-    static version = [1,0,0];
+    static version = [1,0,1];
 
     // Registers
     static TEMP_CFG_REG  = 0x1F;
@@ -52,8 +52,6 @@ class LIS3DH {
     constructor(i2c, addr = 0x30) {
         _i2c = i2c;
         _addr = addr;
-
-        init();
     }
 
 
@@ -292,7 +290,7 @@ class LIS3DH {
 
     // Enables/disables interrupt latching
     function configureInterruptLatching(state) {
-        _setRegBit(CTRL_REG5, 1, state ? 1 : 0);
+        _setRegBit(CTRL_REG5, 3, state ? 1 : 0);
     }
 
     // Returns interrupt registers as a table, and clears the INT1_SRC register

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ i2c.configure(CLOCK_SPEED_400_KHZ);
 accel <- LIS3DH(i2c, 0x32); // using a non-default I2C address (SA0 pulled high)
 ```
 
+### init()
+Sets default values for registers, read the current range and set _range.  Resets to state when first powered on.
+
+
 ### setDataRate(*rate_hz*)
 The *setDataRate* method sets the Output Data Rate (ODR) of the accelerometer in Hz. The nearest supported data rate less than or equal to the requested rate will be used and returned. Supported datarates are 0 (Shutdown), 1, 10, 25, 50, 100, 200, 400, 1600, and 5000 Hz.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The [LIS3DH](http://www.st.com/st-web-ui/static/active/en/resource/technical/doc
 
 The LPS25H can interface over I&sup2;C or SPI. This class addresses only I&sup2;C for the time being.
 
-To add this library to your project, add #require "LIS3DH.class.nut:1.0.0" to the top of your device code.
+To add this library to your project, add #require "LIS3DH.class.nut:1.0.1" to the top of your device code.
 
 ## Class Methods
 
@@ -19,7 +19,7 @@ The class’ constructor takes one required parameter (a configured imp I&sup2;C
 | addr          | byte         | 0x30    | The I&sup2;C address of the accelerometer |
 
 ```squirrel
-#require "LIS3DH.class.nut:1.0.0"
+#require "LIS3DH.class.nut:1.0.1"
 
 i2c <- hardware.i2c89;
 i2c.configure(CLOCK_SPEED_400_KHZ);
@@ -274,7 +274,7 @@ accel.setLowPower(true);
 The *reset* method resets all registers to datasheet default values. The reset method can be very useful during active development (as 'Build and Run' will not reset the IC).
 
 ```squirrel
-#require "LIS3DH.class.nut:1.0.0"
+#require "LIS3DH.class.nut:1.0.1"
 
 i2c <- hardware.i2c89;
 i2c.configure(CLOCK_SPEED_400_KHZ);
@@ -287,4 +287,4 @@ accel.reset();
 
 ## License
 
-The LIS3DH class is licensed under [MIT License](./LICENSE).
+The LIS3DH class is licensed under [MIT License](https://github.com/electricimp/lis3dh/blob/master/LICENSE).


### PR DESCRIPTION
Changed version number

Fixed register in #configureInterruptLatching

Removed #init method from the constructor
- when called in the constructor #init clears the interrupt pins before they can be polled
