### PR TITLE
V1.0.2

### DIFF
--- a/LIS3DH.class.nut
+++ b/LIS3DH.class.nut
@@ -273,7 +273,7 @@ class LIS3DH {
 
         // Set the CLICK_THS register
         if (threshold < 0) { threshold = threshold * -1.0; }    // Make sure we have a positive value
-        if (threshold > _range) { threshold = range; }          // Make sure it doesn't exceed the _range
+        if (threshold > _range) { threshold = _range; }          // Make sure it doesn't exceed the _range
 
         threshold = (((threshold * 1.0) / (_range * 1.0)) * 127).tointeger();
         _setReg(CLICK_THS, threshold);

--- a/LIS3DH.class.nut
+++ b/LIS3DH.class.nut
@@ -1,5 +1,5 @@
 class LIS3DH {
-    static version = [1,0,1];
+    static version = [1,0,2];
 
     // Registers
     static TEMP_CFG_REG  = 0x1F;
@@ -52,6 +52,9 @@ class LIS3DH {
     constructor(i2c, addr = 0x30) {
         _i2c = i2c;
         _addr = addr;
+
+        // Read the range + set _range property
+        getRange();
     }
 
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The [LIS3DH](http://www.st.com/st-web-ui/static/active/en/resource/technical/doc
 
 The LPS25H can interface over I&sup2;C or SPI. This class addresses only I&sup2;C for the time being.
 
-To add this library to your project, add #require "LIS3DH.class.nut:1.0.1" to the top of your device code.
+To add this library to your project, add #require "LIS3DH.class.nut:1.0.2" to the top of your device code.
 
 ## Class Methods
 
@@ -19,7 +19,7 @@ The class’ constructor takes one required parameter (a configured imp I&sup2;C
 | addr          | byte         | 0x30    | The I&sup2;C address of the accelerometer |
 
 ```squirrel
-#require "LIS3DH.class.nut:1.0.1"
+#require "LIS3DH.class.nut:1.0.2"
 
 i2c <- hardware.i2c89;
 i2c.configure(CLOCK_SPEED_400_KHZ);
@@ -274,7 +274,7 @@ accel.setLowPower(true);
 The *reset* method resets all registers to datasheet default values. The reset method can be very useful during active development (as 'Build and Run' will not reset the IC).
 
 ```squirrel
-#require "LIS3DH.class.nut:1.0.1"
+#require "LIS3DH.class.nut:1.0.2"
 
 i2c <- hardware.i2c89;
 i2c.configure(CLOCK_SPEED_400_KHZ);


### PR DESCRIPTION
_range set in constructor
_range typo fixed in configureClickInterrupt
updated version number to v1.0.2
