### PR TITLE
v2.0.2

### DIFF
--- a/.impt.test
+++ b/.impt.test
@@ -5,8 +5,8 @@
   "allowDisconnect": false,
   "builderCache": false,
   "testFiles": [
-    "*.test.nut",
-    "tests/**/*.test.nut"
+    "LIS3DH.automated.device.test.nut",
+    "tests/**/LIS3DH.automated.device.test.nut"
   ],
   "deviceFile": "LIS3DH.device.lib.nut"
 }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The [LIS3DH](http://www.st.com/st-web-ui/static/active/en/resource/technical/doc
 
 This library also supports the LIS2DH12, another widely used three-axis MEMS accelerometer and which can be found on [Electric Imp’s impExplorer&trade; Kit](https://developer.electricimp.com/gettingstarted/devkits).
 
-**To add this library to your project, add** `#require "LIS3DH.device.lib.nut:2.0.1"` **to the top of your device code**
+**To add this library to your project, add** `#require "LIS3DH.device.lib.nut:2.0.2"` **to the top of your device code**
 
 ## Class Usage ##
 
@@ -200,7 +200,7 @@ This method sets the measurement range of the sensor in Gs. Supported ranges are
 
 #### Return Value ####
 
-Integer &mdash; the current measurement range. 
+Integer &mdash; the current measurement range.
 
 #### Example ####
 
@@ -216,7 +216,7 @@ This method returns the currently-set measurement range of the sensor in Gs.
 
 #### Return Value ####
 
-Integer &mdash; the current measurement range. 
+Integer &mdash; the current measurement range.
 
 ```
 server.log(format("Current Sensor Range is +/- %dG", accel.getRange()));
@@ -245,7 +245,7 @@ This method configures an interrupt when the FIFO buffer reaches the set waterma
 
 #### Return Value ####
 
-Nothing. 
+Nothing.
 
 #### Example ####
 
@@ -333,7 +333,7 @@ The following is taken from the from [LIS3DH Datasheet](http://www.st.com/st-web
 
 #### Return Value ####
 
-Nothing. 
+Nothing.
 
 #### Example ####
 
@@ -357,7 +357,7 @@ This method configures the intertial interrupt generator to generate interrupts 
 
 #### Return Value ####
 
-Nothing. 
+Nothing.
 
 #### Example ####
 
@@ -384,7 +384,7 @@ This method configures the click interrupt generator.
 
 #### Return Value ####
 
-Nothing. 
+Nothing.
 
 #### Single Click Example ####
 
@@ -412,7 +412,7 @@ This method enables (*state* is `true`) or disables (*state* is `false`) data-re
 
 #### Return Value ####
 
-Nothing. 
+Nothing.
 
 #### Example ####
 
@@ -435,7 +435,7 @@ Interrupt latching is disabled by default.
 
 #### Return Value ####
 
-Nothing. 
+Nothing.
 
 #### Example ####
 
@@ -524,7 +524,7 @@ function takeReading() {
     } else {
       // add timestamp to result table
       result.ts <- time();
-      
+
       // log reading
       foreach(k, v in result) {
         server.log(k + ": " + v);
@@ -635,7 +635,7 @@ This method configures the high-pass filter.
 
 #### Return Value ####
 
-Nothing. 
+Nothing.
 
 #### Example ####
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ This method enables or disables all three axes on the accelerometer. Calling the
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| *state* | Boolean | No | Activate (`true`) or disable (`false`) the accelerometer is active (Default: `true`) |
+| *state* | Boolean | No | Activate (`true`) or disable (`false`) the accelerometer (Default: `true`) |
 
 #### Return Value ####
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ This method enables or disables all three axes on the accelerometer. Calling the
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| *state* | Boolean | No | Activate (`true`) or disable (`false`) the acceleromater is active (Default: `true`) |
+| *state* | Boolean | No | Activate (`true`) or disable (`false`) the accelerometer is active (Default: `true`) |
 
 #### Return Value ####
 

--- a/tests/LIS3DH.automated.device.test.nut
+++ b/tests/LIS3DH.automated.device.test.nut
@@ -54,23 +54,12 @@ class MyTestCase extends ImpTestCase {
         this.assertEqual(myVal, accel._getReg(LIS3DH_CTRL_REG3));
     }
 
-    function testInterruptLatching() {
-        local accel = getLIS();
-        accel.configureInterruptLatching(true);
-        accel.configureClickInterrupt(true);
-        accel.configureInertialInterrupt(true);
-
-        imp.sleep(DATA_WAIT); // hopefully something gets asserted in this time
-
-        this.assertTrue(accel.getInterruptTable() != 0);
-    }
-
     function testConstruction() {
         local accel = LIS3DH(_i2c, 0x32);
         this.assertTrue(accel._addr == 0x32);
     }
 
-    // test that calling reset correctly resets registers (in particular, 
+    // test that calling reset correctly resets registers (in particular,
     // data ready interrupt and range)
     function testInit() {
         local accel = LIS3DH(_i2c, 0x32);
@@ -114,7 +103,7 @@ class MyTestCase extends ImpTestCase {
         local accel = getLIS();
         local res = accel.getAccel();
         this.assertTrue(("x" in res ? typeof res.x == "float" : false) &&
-                        ("y" in res ? typeof res.y == "float" : false) && 
+                        ("y" in res ? typeof res.y == "float" : false) &&
                         ("z" in res ? typeof res.z == "float" : false));
     }
 
@@ -123,7 +112,7 @@ class MyTestCase extends ImpTestCase {
             local accel = getLIS();
             accel.getAccel(function(res) {
                 if (("x" in res ? typeof res.x == "float" : false) &&
-                    ("y" in res ? typeof res.y == "float" : false) && 
+                    ("y" in res ? typeof res.y == "float" : false) &&
                     ("z" in res ? typeof res.z == "float" : false)) {
                     resolve("async resolved successfully");
                 } else {
@@ -145,7 +134,7 @@ class MyTestCase extends ImpTestCase {
                     accel.enable(true);
                     imp.wakeup(DATA_WAIT, function() {
                         res = accel.getAccel();
-                        // technically it's possible to have all axes at 0 
+                        // technically it's possible to have all axes at 0
                         // acceleration but it's unlikedly
                         if (!(res.x || res.y || res.z)) {
                             reject("failed to enable axes");
@@ -153,7 +142,7 @@ class MyTestCase extends ImpTestCase {
                             resolve("successfully disabled and enabled axes");
                         }
                     }.bindenv(this));
-                }   
+                }
             }.bindenv(this));
         }.bindenv(this))
     }

--- a/tests/LIS3DH.manual.device.test.nut
+++ b/tests/LIS3DH.manual.device.test.nut
@@ -85,7 +85,7 @@ class MyTestCase extends ImpTestCase {
                     reject("ADC did not receive correct reading on channel 1");
                 }
             }.bindenv(this));
-        }.bindenv(this));        
+        }.bindenv(this));
     }
     */
 
@@ -105,7 +105,7 @@ class MyTestCase extends ImpTestCase {
         this.assertTrue(accel._addr == 0x32);
     }
 
-    // test that calling reset correctly resets registers (in particular, 
+    // test that calling reset correctly resets registers (in particular,
     // data ready interrupt and range)
     function testInit() {
         local accel = LIS3DH(_i2c, 0x32);
@@ -149,7 +149,7 @@ class MyTestCase extends ImpTestCase {
         local accel = getLIS();
         local res = accel.getAccel();
         this.assertTrue(("x" in res ? typeof res.x == "float" : false) &&
-                        ("y" in res ? typeof res.y == "float" : false) && 
+                        ("y" in res ? typeof res.y == "float" : false) &&
                         ("z" in res ? typeof res.z == "float" : false));
     }
 
@@ -158,7 +158,7 @@ class MyTestCase extends ImpTestCase {
             local accel = getLIS();
             accel.getAccel(function(res) {
                 if (("x" in res ? typeof res.x == "float" : false) &&
-                    ("y" in res ? typeof res.y == "float" : false) && 
+                    ("y" in res ? typeof res.y == "float" : false) &&
                     ("z" in res ? typeof res.z == "float" : false)) {
                     resolve("async resolved successfully");
                 } else {
@@ -180,7 +180,7 @@ class MyTestCase extends ImpTestCase {
                     accel.enable(true);
                     imp.wakeup(DATA_WAIT, function() {
                         res = accel.getAccel();
-                        // technically it's possible to have all axes at 0 
+                        // technically it's possible to have all axes at 0
                         // acceleration but it's unlikedly
                         if (!(res.x || res.y || res.z)) {
                             reject("failed to enable axes");
@@ -188,7 +188,7 @@ class MyTestCase extends ImpTestCase {
                             resolve("successfully disabled and enabled axes");
                         }
                     }.bindenv(this));
-                }   
+                }
             }.bindenv(this));
         }.bindenv(this))
     }


### PR DESCRIPTION
fixed click interrupt latching bug
removed manual interrupt test from automated tests 
updated test config file to only run automated tests
fixed typo in test file names
added LIS3DH_TEMP_CFG_REG to reset, so all registers the library sets are restored to defaults by reset method
increased version number v2.0.2